### PR TITLE
Build off develop branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,13 +27,16 @@ RUN mkdir -p /tmp/downloads $OPT/bin $OPT/etc $OPT/lib $OPT/share $OPT/site /tmp
 WORKDIR /tmp/downloads
 
 # PCAP-core
-RUN curl -L -o master.zip --retry 10 https://github.com/ICGC-TCGA-PanCancer/PCAP-core/archive/master.zip && \
-    mkdir /tmp/downloads/distro && \
-    bsdtar -C /tmp/downloads/distro --strip-components 1 -xf master.zip && \
-    cd /tmp/downloads/distro && \
-    ./setup.sh $OPT && \
-    cd /tmp/downloads && \
-    rm -rf master.zip /tmp/downloads/distro /tmp/hts_cache
+RUN git clone --recursive https://github.com/ICGC-TCGA-PanCancer/PCAP-core.git pcap && \
+    cd pcap && ./setup.sh $OPT
+
+#curl -L -o master.zip --retry 10 https://github.com/ICGC-TCGA-PanCancer/PCAP-core/archive/master.zip && \
+#    mkdir /tmp/downloads/distro && \
+#    bsdtar -C /tmp/downloads/distro --strip-components 1 -xf master.zip && \
+#    cd /tmp/downloads/distro && \
+#    ./setup.sh $OPT && \
+#    cd /tmp/downloads && \
+#    rm -rf master.zip /tmp/downloads/distro /tmp/hts_cache
 
 # alleleCount
 RUN curl -L -o master.zip --retry 10 https://github.com/cancerit/alleleCount/archive/master.zip && \


### PR DESCRIPTION
After seeing this go by on Slack I gave building it a try. The Docker build seems to work fine on my Ubuntu dev box (14.04) after switching to PCAP:develop.

Could be good to move to git submodules for the included packages (looks like most of them are on github). It's worked well for us with vg, and doesn't break the build if master.zip gets a silent update that's incompatible with everything else.